### PR TITLE
Try to download beatmaps without video on fail.

### DIFF
--- a/chimu/v1/routes/download.py
+++ b/chimu/v1/routes/download.py
@@ -28,7 +28,10 @@ async def download_set(request: Request):
 
     beatmap = await RequestDownload(set_id, no_video)
     if beatmap == None:
-        return Error(404, ERR_CODE_BEATMAP_NOT_FOUND, f'Error: Beatmap not found!')
+        if no_video == 0:
+            beatmap = await RequestDownload(set_id, 1)
+        if beatmap == None:
+            return Error(404, ERR_CODE_BEATMAP_NOT_FOUND, f'Error: Beatmap not found!')
 
     if beatmap['IpfsHash'] == None or beatmap['IpfsHash'] == '':
         return Error(404, ERR_CODE_BEATMAP_UNAVAILABLE, f'Error: Beatmap unavailable!')


### PR DESCRIPTION
no_video is strictly 0 by default, so my suspicion is that it tries to always download video, and if there is no video available, it fails